### PR TITLE
Add colon to non-word characters

### DIFF
--- a/flx.el
+++ b/flx.el
@@ -91,7 +91,7 @@
 (defsubst flx-is-word (char)
   "returns t if char is word"
   (and char
-       (not (memq char '(?\  ?- ?_ ?. ?/ ?\\)))))
+       (not (memq char '(?\  ?- ?_ ?: ?. ?/ ?\\)))))
 
 (defsubst flx-is-capital (char)
   "returns t if char is word"


### PR DESCRIPTION
It's common in an init file to use the naming convention my:function.
This commit enables flx to better match those functions.
