### PR TITLE
Update a few predicate functions according to the common Emacs Lisp style

### DIFF
--- a/flx.el
+++ b/flx.el
@@ -70,23 +70,26 @@
     res))
 
 ;;; Do we need more word separators than ST?
-(defsubst flx-is-word (char)
-  "returns t if char is word"
+(defsubst flx-word-p (char)
+  "Check if CHAR is a word character."
   (and char
        (not (memq char '(?\  ?- ?_ ?: ?. ?/ ?\\)))))
 
-(defsubst flx-is-capital (char)
-  "returns t if char is word"
+(defsubst flx-capital-p (char)
+  "Check if CHAR is an uppercase character."
   (and char
        (and (<= char ?Z)
             (<= ?A char))))
 
-(defsubst flx-is-boundary (last-char char)
+(defsubst flx-boundary-p (last-char char)
+  "Check is LAST-CHAR is the end of a word and CHAR the start of the next.
+
+The function is camel-case aware."
   (or (null last-char)
-      (and (not (flx-is-capital last-char))
-           (flx-is-capital char))
-      (and (not (flx-is-word last-char))
-           (flx-is-word char))))
+      (and (not (flx-capital-p last-char))
+           (flx-capital-p char))
+      (and (not (flx-word-p last-char))
+           (flx-word-p char))))
 
 (defsubst flx-inc-vec (vec &optional inc beg end)
   "increment each element of vectory by INC(default=1)
@@ -127,10 +130,10 @@ See documentation for logic."
                       ;; considered words of length 1.  This is so "foo/__ab"
                       ;; gets penalized compared to "foo/ab".
                       (if (zerop group-word-count) nil last-char)))
-                 (when (flx-is-boundary effective-last-char char)
+                 (when (flx-boundary-p effective-last-char char)
                    (setcdr (cdar groups-alist) (cons index (cddar groups-alist))))
-                 (when (and (not (flx-is-word last-char))
-                            (flx-is-word char))
+                 (when (and (not (flx-word-p last-char))
+                            (flx-word-p char))
                    (incf group-word-count)))
                ;; ++++ -45 penalize extension
                (when (eq last-char penalty-lead)

--- a/tests/flx-test.el
+++ b/tests/flx-test.el
@@ -1,37 +1,17 @@
-;;; flx-test.el ---
+;;; flx-test.el --- flx ert unit tests
 
-;; this file is not part of Emacs
+;; Copyright © 2013 Le Wang
 
-;; Copyright (C) 2013 Le Wang
 ;; Author: Le Wang
 ;; Maintainer: Le Wang
-;; Description:
-;; Author: Le Wang
-;; Maintainer: Le Wang
-
+;; Description: fuzzy matching with good sorting
 ;; Created: Tue Apr 16 23:32:32 2013 (+0800)
-;; Version: 0.1
-;; Last-Updated:
-;;           By:
-;;     Update #: 10
-;; URL:
-;; Keywords:
-;; Compatibility:
+;; URL: https://github.com/lewang/flx
 
-;;; Installation:
+;; This file is NOT part of GNU Emacs.
 
-;;
-;;
-;;
+;;; License
 
-;;; Commentary:
-
-;;
-;;
-;;
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as
 ;; published by the Free Software Foundation; either version 3, or
@@ -46,8 +26,8 @@
 ;; along with this program; see the file COPYING.  If not, write to
 ;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth
 ;; Floor, Boston, MA 02110-1301, USA.
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; Commentary:
 
 ;;; Code:
 
@@ -70,23 +50,23 @@
              h)
     (should (= 3 count))))
 
-(ert-deftest flx-is-boundary ()
-  (should (flx-is-boundary ?/ ?a))
-  (should (flx-is-boundary nil ?a))
-  (should-not (flx-is-boundary ?a ?/))
-  (should (flx-is-boundary ?/ ?A))
-  (should (flx-is-boundary ?a ?A)))
+(ert-deftest flx-boundary-p ()
+  (should (flx-boundary-p ?/ ?a))
+  (should (flx-boundary-p nil ?a))
+  (should-not (flx-boundary-p ?a ?/))
+  (should (flx-boundary-p ?/ ?A))
+  (should (flx-boundary-p ?a ?A)))
 
-(ert-deftest flx-is-capital ()
-  (should (flx-is-capital ?A))
-  (should (flx-is-capital ?Z))
-  (should-not (flx-is-capital ?_))
-  (should-not (flx-is-capital ?a)))
+(ert-deftest flx-capital-p ()
+  (should (flx-capital-p ?A))
+  (should (flx-capital-p ?Z))
+  (should-not (flx-capital-p ?_))
+  (should-not (flx-capital-p ?a)))
 
-(ert-deftest flx-is-word ()
-  (should (flx-is-word ?a))
-  (should (flx-is-word ?A))
-  (should-not (flx-is-word ?_)))
+(ert-deftest flx-word-p ()
+  (should (flx-word-p ?a))
+  (should (flx-word-p ?A))
+  (should-not (flx-word-p ?_)))
 
 (ert-deftest flx-inc-vec ()
   "roll and unroll should be bring back original score"


### PR DESCRIPTION
In Emacs predicate should name like something-p instead of
is-something. I've updated a few predicate functions and added them
proper docstrings that pass `M-x checkdoc`.

I've also updated the comment header of the tests file.
