### PR TITLE
Make flx-capital-p behave correctly for non-latin words

### DIFF
--- a/flx.el
+++ b/flx.el
@@ -78,8 +78,8 @@
 (defsubst flx-capital-p (char)
   "Check if CHAR is an uppercase character."
   (and char
-       (and (<= char ?Z)
-            (<= ?A char))))
+       (flx-word-p char)
+       (= char (upcase char))))
 
 (defsubst flx-boundary-p (last-char char)
   "Check is LAST-CHAR is the end of a word and CHAR the start of the next.

--- a/tests/flx-test.el
+++ b/tests/flx-test.el
@@ -60,8 +60,10 @@
 (ert-deftest flx-capital-p ()
   (should (flx-capital-p ?A))
   (should (flx-capital-p ?Z))
+  (should (flx-capital-p ?Д))
   (should-not (flx-capital-p ?_))
-  (should-not (flx-capital-p ?a)))
+  (should-not (flx-capital-p ?a))
+  (should-not (flx-capital-p ?д)))
 
 (ert-deftest flx-word-p ()
   (should (flx-word-p ?a))


### PR DESCRIPTION
It's entirely possible for one to have non-latin words in his ido
candidates. This commit improves `flx-capital-p` by making it recognize
non-latin letters.
