### PR TITLE
Make flx-ido depend on flx on package level

### DIFF
--- a/flx-ido.el
+++ b/flx-ido.el
@@ -8,6 +8,7 @@
 ;; Created: Sun Apr 21 20:38:36 2013 (+0800)
 ;; Version: 0.2
 ;; URL: https://github.com/lewang/flx
+;; Package-Requires: ((flx "0.1"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
It makes sense to have `flx` and `flx-ido` as separate packages on repos
like Marmalade and MELPA, since there can be many completion frontends
using the flx matching algorithm.
