### PR TITLE
Fix incorrect word count for camelCase.

### DIFF
--- a/flx.el
+++ b/flx.el
@@ -179,7 +179,7 @@ See documentation for logic."
                                     (1- separator-count)
                                   0)
                                 ;; ++++ basepath word count penalty
-                                (- word-count))
+                                (- words-length))
                            ;; ++++ non-basepath penalties
                            (if (= index 0)
                                -3


### PR DESCRIPTION
The variable `word-count` is only determined on `flx-word-p` which doesn't
break on camelCase changes.  OTOH, `words-length` properly reflects the
number of words (based on `flx-boundary-p`.

Further, we might probably want to remove the `word-count` variable
alltogether, it doesn't serve any purpose as it just mirrors
`words-length` but in an inconsistent way.