### PR TITLE
Add turbochargers

### DIFF
--- a/flx.el
+++ b/flx.el
@@ -258,19 +258,18 @@ See documentation for logic."
                                 (> query-length 1)))
 
          ;; Dynamic Programming table
-         (match-cache (make-hash-table :test 'equal :size 10))
+         (match-cache (make-hash-table :test 'eql :size 10))
 
-         ;; local variables to be used later
-         (best-score most-negative-fixnum)
+         ;; local variable to be used later
          (indexes nil)
 
          ((symbol-function #'flx-get-matches-worker)
           (lambda (greater-than q-index)
             (or
              (gethash
-              (cons greater-than q-index) match-cache)
+              (+ q-index (* (or greater-than 0) query-length)) match-cache)
              (puthash
-              (cons greater-than q-index)
+              (+ q-index (* (or greater-than 0) query-length))
               (progn
                 (setq indexes (flx-bigger-sublist
                                (gethash (aref query q-index) hash)
@@ -279,45 +278,39 @@ See documentation for logic."
                     (mapcar (lambda (index)
                               (cons (list index)
                                     (cons (aref heatmap index) 0))) indexes)
-                  (let ((matches) (duplicate-scores most-negative-fixnum))
-                    (dolist (index indexes matches)
-                      (dolist (elem
-                               (mapcar
-                                (lambda (object)
-                                  (cons (cons index (car object))
-                                        (cons
-                                         (+ (car (cdr object))
-                                            (aref heatmap index)
-                                            (if (= (1- (caar object)) index)
-                                                (+ (* (min (1+ (cddr object))
-                                                           4)
-                                                      15)
-                                                   45)
-                                              0)
-                                            (if (and full-match-boost
-                                                     (= (1+ (length
-                                                             (car object)))
-                                                        (length str)))
-                                                10000
-                                              0))
-                                         (if (= (1- (caar object)) index)
-                                             (1+ (cddr object))
-                                           0))))
-
-                            (flx-get-matches-worker index (1+ q-index))))
-
+                  (let ((match) (best-score most-negative-fixnum))
+                    (dolist (index indexes (and match (list match)))
+                      (dolist (elem (flx-get-matches-worker index (1+ q-index)))
+                        (setq elem
+                          (cons (cons index (car elem))
+                                (cons
+                                 (+ (cadr elem)
+                                    (aref heatmap index)
+                                    (if (= (1- (caar elem)) index)
+                                        (+ (* (min (cddr elem)
+                                                   3)
+                                              15)
+                                           60)
+                                      0))
+                                 (if (= (1- (caar elem)) index)
+                                     (1+ (cddr elem))
+                                   0))))
                         ;; we only care about the optimal score
-                        (when (> (car (cdr elem))
-                                 duplicate-scores)
-                          (setq duplicate-scores (car (cdr elem)))
-                          (push elem matches)))))))
+                        (when (> (cadr elem) best-score)
+                          (setq best-score (cadr elem)
+                                match elem)))))))
               match-cache)))))
 
       ;; postprocess candidate
       (let ((res (flx-get-matches-worker nil 0)))
         (and res
-             (cons (car (cdr (car res)))
-                   (car (car res))))))))
+             (cons (+ (cadar res)
+                      (if (and full-match-boost
+                               (=  (length (caar res))
+                                   (length str)))
+                          10000
+                        0))
+                   (caar res)))))))
 
 (defun flx-propertize (obj score &optional add-score)
   "Return propertized copy of obj according to score.

--- a/tests/flx-test.el
+++ b/tests/flx-test.el
@@ -79,21 +79,6 @@
   (let ((vec (vector 1 2 3)))
     (should (equal (vector 2 3 4) (flx-inc-vec vec)))))
 
-(ert-deftest flx-matches-basic ()
-  (let* ((str "aggg")
-         (h (flx-get-hash-for-string str 'flx-get-heatmap-str))
-         (res (flx-get-matches h "g")))
-    (should (equal res '((1) (2) (3))))))
-
-
-(ert-deftest flx-matches-more ()
-  (let* ((str "ab-gh-ab")
-         (h (flx-get-hash-for-string str 'flx-get-heatmap-str))
-         (res (flx-get-matches h "ab")))
-    (should (equal res '((0 1)
-                         (0 7)
-                         (6 7))))))
-
 (ert-deftest flx-get-heatmap-vector-basic ()
   "see worksheet for derivation"
   (let ((res (flx-get-heatmap-file "__abcab")))


### PR DESCRIPTION
This PR adds the following optimizations:

1. Let bindings are moved out of inner loops, saving stack trashing.
2. Match collection is now implemented with a dynamic programming table.
3. Unpromising branches (i.e. all non-optimal matches) are pruned immediately

The code is, unfortunately, very dense and difficult to follow. I did my best, but I'm pretty sure I broke my brain making this. 

Scoring should behave identically, according to my testing. 

See also:
* #34 
* https://github.com/PythonNut/helm-flx/issues/9
* https://github.com/syl20bnr/spacemacs/issues/3327#issuecomment-150109947
* https://github.com/syl20bnr/spacemacs/issues/3500

This is preliminary and needs some heavy testing. I'm not too sure how the math works out for (3). I think it shouldn't cause any incompatibilities, but I'm to tired to prove it right now.