### PR TITLE
add hack for improved amx compatibility

### DIFF
--- a/flx.el
+++ b/flx.el
@@ -5,7 +5,7 @@
 
 ;; Author: Le Wang
 ;; Maintainer: Le Wang
-;; Description: fuzzy matching with good sorting -- with hacks
+;; Description: fuzzy matching with good sorting
 ;; Created: Wed Apr 17 01:01:41 2013 (+0800)
 ;; Version: 0.6.2
 ;; Package-Requires: ((cl-lib "0.3"))

--- a/flx.el
+++ b/flx.el
@@ -4,12 +4,12 @@
 ;; Copyright © 2018 Arne Babenhauserheide für Disy Informationssysteme GmbH
 
 ;; Author: Le Wang
-;; Maintainer: Arne Babenhauserheide
+;; Maintainer: Le Wang
 ;; Description: fuzzy matching with good sorting -- with hacks
 ;; Created: Wed Apr 17 01:01:41 2013 (+0800)
-;; Version: 0.6.1h
+;; Version: 0.6.2
 ;; Package-Requires: ((cl-lib "0.3"))
-;; URL: https://github.com/ArneBab/flx
+;; URL: https://github.com/lewang/flx
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -31,11 +31,6 @@
 ;; Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
-
-;; This version adds the flx-stop-splitting-regexp, which is a hack to
-;; get good matching with amx even though amx adds the keyboard
-;; shortcut in parentheses
-
 ;; Implementation notes
 ;; --------------------
 ;;
@@ -52,6 +47,10 @@
 ;; Scott Frazer's blog entry http://scottfrazersblog.blogspot.com.au/2009/12/emacs-better-ido-flex-matching.html
 ;; provided a lot of inspiration.
 ;; ido-hacks was helpful for ido optimization
+;; Arne Babenhauserheide added the flx-stop-splitting-regexp, which is
+;; a hack to get good matching with amx even though amx adds the
+;; keyboard shortcut in parentheses
+
 
 ;;; Code:
 

--- a/flx.el
+++ b/flx.el
@@ -67,8 +67,10 @@
   :type '(repeat character)
   :group 'flx)
 
-(defcustom flx-stop-splitting-regexp " (.?-"
-  "If not nil, everything after the delimiter is treated as part as the last word."
+(defcustom flx-stop-splitting-regexp nil
+  "If not nil, everything after the delimiter is treated as part as the last word.
+
+Use  \"(.?-\" to have amx shortcut-info appended to the last word."
   :type '(string)
   :group 'flx)
 

--- a/flx.el
+++ b/flx.el
@@ -99,19 +99,6 @@ This function is camel-case aware."
       (and (not (flx-word-p last-char)) ;; i.e. -a
            (flx-word-p char))))
 
-(defsubst flx-boundary-left-p (last-char char)
-  "Check if LAST-CHAR is the end of a word. 
-
-This function does not match the last word! Use final char bonus for that.
-
-This function is camel-case aware."
-  (and (null last-char) ;; i.e. ^a, never left of a boundary
-       (or
-	(and (not (flx-capital-p last-char)) ;; i.e. aA
-	     (flx-capital-p char))
-	(and (flx-word-p last-char) ;; i.e. a-
-	     (not (flx-word-p char))))))
-
 (defsubst flx-inc-vec (vec &optional inc beg end)
   "Increment each element of vectory by INC(default=1)
 from BEG (inclusive) to END (not inclusive)."


### PR DESCRIPTION
This add the flx-stop-splitting-regexp, which is a hack to get good matching with amx even though amx adds the keyboard shortcut in parentheses.

It is the smallest change I found to work around the problems I described in https://github.com/lewang/flx/issues/63#issuecomment-418653079