### PR TITLE
Enable lexical binding

### DIFF
--- a/flx-ido.el
+++ b/flx-ido.el
@@ -1,4 +1,4 @@
-;;; flx-ido.el --- flx integration for ido
+;;; flx-ido.el --- flx integration for ido -*- lexical-binding: t; -*-
 
 ;; Copyright © 2013, 2015 Le Wang
 

--- a/flx.el
+++ b/flx.el
@@ -1,4 +1,4 @@
-;;; flx.el --- fuzzy matching with good sorting
+;;; flx.el --- fuzzy matching with good sorting -*- lexical-binding: t; -*-
 
 ;; Copyright © 2013, 2015 Le Wang
 

--- a/misc/flx-helm-demo.el
+++ b/misc/flx-helm-demo.el
@@ -1,4 +1,4 @@
-;; Copyright © 2013-2022 Le Wang
+;; Copyright © 2013-2022 Le Wang -*- lexical-binding: t; -*-
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/misc/flx-ido-demo.el
+++ b/misc/flx-ido-demo.el
@@ -1,4 +1,4 @@
-;; Copyright © 2013-2022 Le Wang
+;; Copyright © 2013-2022 Le Wang -*- lexical-binding: t; -*-
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/misc/flx-test-list.el
+++ b/misc/flx-test-list.el
@@ -1,4 +1,4 @@
-;;; This is just a big list of files for experimenting
+;;; This is just a big list of files for experimenting -*- lexical-binding: t; -*-
 
 ;; Copyright © 2013-2022 Le Wang
 


### PR DESCRIPTION
Hi. I have inspected your codebase and found no code which presents a problem with enabling lexical-binding. One day Emacs will enable lexical binding by default so it's better merge this earlier to reduce the risk of a mass config breakage event. This PR will give a free performance boost for all users.