### PR TITLE
Explicitly set lexical-binding

### DIFF
--- a/flx-ido.el
+++ b/flx-ido.el
@@ -1,4 +1,4 @@
-;;; flx-ido.el --- flx integration for ido
+;;; flx-ido.el --- flx integration for ido  -*- lexical-binding: nil -*-
 
 ;; Copyright © 2013, 2015 Le Wang
 

--- a/flx.el
+++ b/flx.el
@@ -1,4 +1,4 @@
-;;; flx.el --- fuzzy matching with good sorting
+;;; flx.el --- fuzzy matching with good sorting  -*- lexical-binding: nil -*-
 
 ;; Copyright © 2013, 2015 Le Wang
 


### PR DESCRIPTION
Explicitly set `lexical-binding` to `nil`.  To avoid surprises
we don't set it to `t`.  Beginning with Emacs 30, this variable
has to be set explicitly in every file, else the byte-compiler
complains.